### PR TITLE
fix : prevent access violation

### DIFF
--- a/Source/TCPWrapper/Private/TCPServerComponent.cpp
+++ b/Source/TCPWrapper/Private/TCPServerComponent.cpp
@@ -161,19 +161,6 @@ void UTCPServerComponent::StartListenServer(const int32 InListenPort)
 			//sleep for 100microns
 			FPlatformProcess::Sleep(0.0001);
 		}//end while
-
-		for (auto ClientPair : Clients)
-		{
-			ClientPair.Value->Socket->Close();
-		}
-		Clients.Empty();
-
-		//Server ended
-		AsyncTask(ENamedThreads::GameThread, [&]()
-		{
-			Clients.Empty();
-			OnListenEnd.Broadcast();
-		});
 	});
 }
 
@@ -188,6 +175,12 @@ void UTCPServerComponent::StopListenServer()
 		ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->DestroySocket(ListenSocket);
 		ListenSocket = nullptr;
 
+		for (auto ClientPair : Clients)
+		{
+			ClientPair.Value->Socket->Close();
+		}
+		Clients.Empty();
+		
 		OnListenEnd.Broadcast();
 	}
 }


### PR DESCRIPTION
This commit moves the cleanup and delegate broadcasting code from the AsyncTask to the end of the StopListenServer() function.

<br>

1. Prevent Access to Destroyed Object Resources:

By executing `Clients.Empty()` and `OnListenEnd.Broadcast()`; directly within StopListenServer(), we ensure that these operations occur before the object is destroyed. This prevents the game thread from accessing invalidated resources, thereby avoiding potential access violations or unexpected behavior.

2. Avoid Deadlocks:

Maintaining the AsyncTask approach and waiting for its completion can lead to potential deadlocks on the game thread. Removing the AsyncTask and handling cleanup directly within `StopListenServer()` eliminates this risk, ensuring smoother and safer thread operations.